### PR TITLE
Minor js tweaks: use `typeof` as operator + add missing semicolons

### DIFF
--- a/src/Text/Base64.js
+++ b/src/Text/Base64.js
@@ -1,17 +1,17 @@
 // module Text.Base64
 
 exports.encode64 = function (str) {
-  if (typeof(btoa) == 'undefined') {
+  if (typeof btoa == 'undefined') {
     return new Buffer(str).toString('base64');
   } else {
     return btoa(str);
   }
-}
+};
 
 exports.decode64 = function (code) {
-  if (typeof(atob) == 'undefined') {
+  if (typeof atob == 'undefined') {
     return new Buffer(code, 'base64').toString('ascii');
   } else {
     return atob(code);
   }
-}
+};

--- a/src/Text/Base64.js
+++ b/src/Text/Base64.js
@@ -1,7 +1,7 @@
 // module Text.Base64
 
 exports.encode64 = function (str) {
-  if (typeof btoa == 'undefined') {
+  if (typeof btoa === 'undefined') {
     return new Buffer(str).toString('base64');
   } else {
     return btoa(str);
@@ -9,7 +9,7 @@ exports.encode64 = function (str) {
 };
 
 exports.decode64 = function (code) {
-  if (typeof atob == 'undefined') {
+  if (typeof atob === 'undefined') {
     return new Buffer(code, 'base64').toString('ascii');
   } else {
     return atob(code);


### PR DESCRIPTION
I had problem with this package compilation under `purs-0.13.3` because of usage of `typeof(_)` as a function. I've turned it into operator application syntax `typeof _`.